### PR TITLE
Add voltage compensation

### DIFF
--- a/src/main/deploy/config.properties
+++ b/src/main/deploy/config.properties
@@ -34,6 +34,8 @@ GRABBER_TALON_2=14
 PCM=0
 PDP=0
 
+### DIGITAL I/O PORTS ###
+LIMIT_SWITCH=10
 
 ### PCM PORTS ###
 
@@ -85,15 +87,23 @@ WHEEL_DIAMETER=0.5
 WHEELBASE = 3.0
 
 
-### CURRENT LIMITING ###
+### ELECTRICAL LIMITING ###
 
 # Current threshold to trigger current limit
 PEAK_CURRENT_AMPS=15
+
 # Duration after current exceed Peak Current has been triggered
 PEAK_TIME_MS=0
+
 # Current to maintain once current limit has been triggered
 CONTIN_CURRENT_AMPS=10
 
+# Max voltage to apply to the hbridge when voltage compensation is enabled
+MAX_VOLTAGE=10
+
+# Number of samples in the rolling average of voltage measurement
+# TODO: may want to adjust to make the compensation more or less responsive
+VOLTAGE_FILTER=32
 
 ### OPERATOR CONTROLS ###
 
@@ -121,6 +131,11 @@ ELEVATOR_TOP_CARGO_BUTTON=11
 
 ### CONFIG ###
 
+# Timeout value in ms. If nonzero, function will wait for config success and report an error if it times out. If zero, no blocking or checking is performed
 TIMEOUT_MS=10
+
+# Parameter slot for the constant
 SLOT_IDX=0
+
+# 0 for Primary closed-loop. 1 for auxiliary closed-loop
 PID_LOOP_IDX=0

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -2,6 +2,7 @@ package frc.robot.subsystems;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 import edu.wpi.first.wpilibj.DigitalInput;
@@ -27,12 +28,15 @@ public class Elevator extends Subsystem {
 
         elevatorMasterTalon = new TalonSRX(Constants.getInt("ELEVATOR_MASTER_TALON"));
         elevatorSlaveTalon = new TalonSRX(Constants.getInt("ELEVATOR_SLAVE_TALON"));
-
-        limitSwitch = new DigitalInput(10);
+        limitSwitch = new DigitalInput(Constants.getInt("LIMIT_SWITCH"));
 
         /* Factory default hardware to prevent unexpected behavior */
         elevatorMasterTalon.configFactoryDefault();
         elevatorSlaveTalon.configFactoryDefault();
+
+        /* Set brake mode */
+        elevatorMasterTalon.setNeutralMode(NeutralMode.Brake);
+        elevatorSlaveTalon.setNeutralMode(NeutralMode.Brake);
 
         /* Current limiting */
         elevatorMasterTalon.configPeakCurrentLimit(Constants.getInt("PEAK_CURRENT_AMPS"), Constants.getInt("TIMEOUT_MS"));
@@ -43,6 +47,11 @@ public class Elevator extends Subsystem {
         elevatorSlaveTalon.configPeakCurrentDuration(Constants.getInt("PEAK_TIME_MS"), Constants.getInt("TIMEOUT_MS"));
         elevatorSlaveTalon.configContinuousCurrentLimit(Constants.getInt("CONTIN_CURRENT_AMPS"), Constants.getInt("TIMEOUT_MS"));
         elevatorSlaveTalon.enableCurrentLimit(true);
+
+        /* Voltage compensation */
+        elevatorMasterTalon.configVoltageCompSaturation(10, Constants.getInt("TIMEOUT_MS"));
+        elevatorMasterTalon.configVoltageMeasurementFilter(Constants.getInt("VOLTAGE_FILTER"), Constants.getInt("TIMEOUT_MS"));
+        elevatorMasterTalon.enableVoltageCompensation(true);
 
         /* Configure Sensor Source for Primary PID */
         elevatorMasterTalon.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative, Constants.getInt("PID_LOOP_IDX"), Constants.getInt("TIMEOUT_MS"));

--- a/src/main/java/frc/robot/subsystems/Feeder.java
+++ b/src/main/java/frc/robot/subsystems/Feeder.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.VictorSPX;
 import edu.wpi.first.wpilibj.command.Subsystem;
 import frc.robot.commands.feeder.FeederControl;
@@ -21,6 +22,12 @@ public class Feeder extends Subsystem {
     private Feeder() {
 
         feederVictor = new VictorSPX(Constants.getInt("FEEDER_VICTOR"));
+
+        /* Factory default to prevent unexpected behavior */
+        feederVictor.configFactoryDefault();
+
+        /* Set brake mode */
+        feederVictor.setNeutralMode(NeutralMode.Brake);
 
     }
 

--- a/src/main/java/frc/robot/subsystems/Grabber.java
+++ b/src/main/java/frc/robot/subsystems/Grabber.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 import edu.wpi.first.wpilibj.command.Subsystem;
 import frc.robot.commands.grabber.GrabberControl;
@@ -22,6 +23,14 @@ public class Grabber extends Subsystem {
 
         grabberTalon1 = new TalonSRX(Constants.getInt("GRABBER_TALON_1"));
         grabberTalon2 = new TalonSRX(Constants.getInt("GRABBER_TALON_2"));
+
+        /* Factory default hardware to prevent unexpected behavior */
+        grabberTalon1.configFactoryDefault();
+        grabberTalon2.configFactoryDefault();
+
+        /* Set brake mode */
+        grabberTalon1.setNeutralMode(NeutralMode.Brake);
+        grabberTalon2.setNeutralMode(NeutralMode.Brake);
 
     }
 


### PR DESCRIPTION
We set the max voltage to around 10V for consistency in our control loops. It would be hard to tune systems that have variable max voltages, such as 12V in the beginning of a match and then 11.5V mid-match. Voltage is directly proportional to motor speed.